### PR TITLE
Strict mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prepack": "tsc --project tsconfig.dist.json --outdir dist --module commonjs --sourcemap --declaration"
   },
   "devDependencies": {
+    "@types/mocha": "^7.0.2",
     "@types/node": "^13.13.5",
     "eslint": "^6.8.0",
     "expect": "^25.3.0",

--- a/src/controller/promise-controller.ts
+++ b/src/controller/promise-controller.ts
@@ -3,7 +3,7 @@ import { HaltError, swallowHalt } from '../halt-error';
 
 export class PromiseController<TOut> implements Controller<TOut> {
   private promise: Promise<TOut>;
-  private _reject: (error: Error) => void;
+  private _reject?: (error: Error) => void;
 
   constructor(promise: PromiseLike<TOut>) {
     this.promise = new Promise((resolve, reject) => {
@@ -13,7 +13,7 @@ export class PromiseController<TOut> implements Controller<TOut> {
   }
 
   async halt() {
-    this._reject(new HaltError());
+    this._reject && this._reject(new HaltError());
 
     await this.promise.catch(swallowHalt);
   }

--- a/src/halt-error.ts
+++ b/src/halt-error.ts
@@ -12,7 +12,7 @@ export function isHaltError(value: any): value is HaltError {
   return !!(value && value.__isEffectionHaltError);
 }
 
-export function swallowHalt(error) {
+export function swallowHalt(error: Error) {
   if(!isHaltError(error)) {
     throw error;
   }

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -1,7 +1,7 @@
 import { Task } from './task';
 
 export type Operation<TOut> =
-  ((task: Task<TOut>) => Iterator<Operation<unknown>, TOut, any>) |
-  Iterator<Operation<unknown>, TOut, any> |
+  ((task: Task<TOut>) => Generator<Operation<unknown>, TOut | undefined, any>) |
+  Generator<Operation<unknown>, TOut | undefined, any> |
   PromiseLike<TOut> |
   undefined

--- a/src/task.ts
+++ b/src/task.ts
@@ -54,7 +54,7 @@ export class Task<TOut> implements PromiseLike<TOut> {
 
   spawn<R>(operation?: Operation<R>): Task<R> {
     let child = new Task(operation);
-    this.children.add(child);
+    this.children.add(child as Task<unknown>);
     return child;
   }
 }

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -1,7 +1,7 @@
 import { describe, beforeEach, it } from 'mocha';
 import * as expect from 'expect';
 
-import { run } from '../src/index';
+import { run, Operation } from '../src/index';
 
 process.on('unhandledRejection', (reason, promise) => {
   // silence warnings in tests
@@ -75,6 +75,7 @@ describe('run', () => {
         let two: number;
         try {
           yield Promise.reject(error);
+          two = 9;
         } catch(e) {
           // swallow error and yield in catch block
           two = yield Promise.resolve(8);
@@ -98,7 +99,7 @@ describe('run', () => {
     });
 
     it('can suspend in finally block', async () => {
-      let callable;
+      let callable: Operation<unknown>
       let eventually = new Promise((resolve) => {
         callable = function*() { resolve('did run'); }
       });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "esnext",
     "moduleResolution": "node",
-    "noImplicitAny": false,
+    "strict": true,
     "typeRoots": [
       "./node_modules/@types",
       "./typings"

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,6 +58,11 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/mocha@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-7.0.2.tgz#b17f16cf933597e10d6d78eae3251e692ce8b0ce"
+  integrity sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==
+
 "@types/node@^13.13.5":
   version "13.13.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.5.tgz#96ec3b0afafd64a4ccea9107b75bf8489f0e5765"


### PR DESCRIPTION
This enables typescript strict mode. This highlights two issues:

1) We have to use `Generator` instead of `Iterator`, since the `return` and `throw` functions are not mandatory for `Iterator`, and we're currently not doing anything sensible if they are absent.

2) The TReturn of a generator has to be `TOut | undefined`, because in the case of a halt, there is no sensible value to return from the generator.