### PR TITLE
Remove generators as a valid operation type

### DIFF
--- a/src/operation.ts
+++ b/src/operation.ts
@@ -2,6 +2,5 @@ import { Task } from './task';
 
 export type Operation<TOut> =
   ((task: Task<TOut>) => Generator<Operation<any>, TOut | undefined, any>) |
-  Generator<Operation<any>, TOut | undefined, any> |
   PromiseLike<TOut> |
   undefined

--- a/src/sleep.ts
+++ b/src/sleep.ts
@@ -1,14 +1,16 @@
 import { Operation } from './operation';
 
-export function *sleep(duration: number): Operation<void> {
-  let timeoutId;
-  try {
-    yield new Promise((resolve) => {
-      setTimeout(resolve, duration);
-    });
-  } finally {
-    if(timeoutId) {
-      clearTimeout(timeoutId);
+export function sleep(duration: number): Operation<void> {
+  return function*() {
+    let timeoutId;
+    try {
+      yield new Promise((resolve) => {
+        setTimeout(resolve, duration);
+      });
+    } finally {
+      if(timeoutId) {
+        clearTimeout(timeoutId);
+      }
     }
   }
 }

--- a/src/task.ts
+++ b/src/task.ts
@@ -34,8 +34,6 @@ export class Task<TOut = unknown> implements Promise<TOut> {
       this.controller = new PromiseController(new Promise(() => {}));
     } else if(isPromise(operation)) {
       this.controller = new PromiseController(operation);
-    } else if(isGenerator(operation)) {
-      this.controller = new IteratorController(operation);
     } else if(typeof(operation) === 'function') {
       this.controller = new IteratorController(operation(this));
     } else {

--- a/test/spawn.test.ts
+++ b/test/spawn.test.ts
@@ -1,23 +1,12 @@
 import { describe, beforeEach, it } from 'mocha';
 import * as expect from 'expect';
 
-import { run, Task } from '../src/index';
+import { run, sleep, Task } from '../src/index';
 import { Deferred } from '../src/deferred';
 
 process.on('unhandledRejection', (reason, promise) => {
   // silence warnings in tests
 });
-
-function* sleep(ms: number) {
-  let timeout;
-  let deferred = Deferred();
-  try {
-    timeout = setTimeout(deferred.resolve, ms);
-    yield deferred.promise;
-  } finally {
-    timeout && clearTimeout(timeout);
-  }
-};
 
 describe('spawn', () => {
   it('can spawn a new child task', async () => {
@@ -152,7 +141,7 @@ describe('spawn', () => {
   it('throws an error when called after controller finishes', async () => {
     let child;
     let root = run(function*(context: Task) {
-      child = context.spawn(function*() {
+      child = context.spawn(function*(task) {
         try {
           yield sleep(1);
         } finally {


### PR DESCRIPTION
Currently we allow both generator functions and instantiated generators as operation types. This change removes support for instantiated generators entirely.

The reason to do this is that being able to pass a generator is confusing and inconsistent. We've actually seen many strange bugs due to this in BigTest, where simply changing to a generator function fixed the issue. The problem is that generators are not *sharable*. A generator being polled by two tasks at the same time will cause indeterminate results. A generator function on the other hand can safely be invoked by both tasks.

This also creates consistency, where the first argument to a generator function is *always* the task, and we are not tempted to pass arguments to the generator function itself, like with the `sleep` function which has been updated in this PR.