### PR TITLE
Add `operation` higher order function

### DIFF
--- a/src/operation.ts
+++ b/src/operation.ts
@@ -1,7 +1,15 @@
 import { Task } from './task';
 
+export type OperationGenerator<TOut> = Generator<Operation<any>, TOut | undefined, any>;
+
+export type OperationFunction<TOut> = (task: Task<TOut>) => OperationGenerator<TOut>;
+
 export type Operation<TOut> =
-  ((task: Task<TOut>) => Generator<Operation<any>, TOut | undefined, any>) |
-  Generator<Operation<any>, TOut | undefined, any> |
+  OperationFunction<TOut> |
+  OperationGenerator<TOut> |
   PromiseLike<TOut> |
   undefined
+
+export function operation<TOut, TArgs extends unknown[]>(fn: (task: Task<TOut>, ...args: TArgs) => OperationGenerator<TOut>): (...args: TArgs) => Operation<TOut> {
+  return (...args: TArgs) => (task) => fn(task, ...args)
+}

--- a/src/sleep.ts
+++ b/src/sleep.ts
@@ -1,6 +1,6 @@
-import { Operation } from './operation';
+import { operation } from './operation';
 
-export function *sleep(duration: number): Operation<void> {
+export const sleep = operation(function*(task, duration: number) {
   let timeoutId;
   try {
     yield new Promise((resolve) => {
@@ -11,4 +11,4 @@ export function *sleep(duration: number): Operation<void> {
       clearTimeout(timeoutId);
     }
   }
-}
+});


### PR DESCRIPTION
This adds a higher order function `operation` which basically curries an operation so that it can be defined with the arguments in the same function as the task, but can be invoked with the arguments first. This is useful, because it removes the need for an outer *wrapping* function in the case where the operation should take arguments, while not requiring effection to know anything about task arguments at all.