### PR TITLE
Add root task which allows discovery of all running tasks

### DIFF
--- a/src/effection.ts
+++ b/src/effection.ts
@@ -1,0 +1,16 @@
+import { Task } from './task';
+
+function createRootTask() {
+  let task = new Task(undefined, { ignoreChildErrors: true });
+  task.start();
+  return task;
+}
+
+export const Effection = {
+  root: createRootTask(),
+
+  async reset() {
+    await Effection.root.halt();
+    Effection.root = createRootTask();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
 import { Operation } from './operation';
 import { Task, TaskOptions } from './task';
 import { HaltError } from './halt-error';
+import { Effection } from './effection';
 
 export { Task, TaskOptions } from './task';
 export { Operation } from './operation';
 export { sleep } from './sleep';
+export { Effection } from './effection';
 
 export function run<TOut>(operation?: Operation<TOut>, options?: TaskOptions): Task<TOut> {
-  let task = new Task(operation, options);
-  task.start();
-  return task;
+  return Effection.root.spawn(operation, options);
 }

--- a/src/task.ts
+++ b/src/task.ts
@@ -21,12 +21,13 @@ export interface Controls<TOut> {
 
 export interface TaskOptions {
   blockParent?: boolean;
+  ignoreChildErrors?: boolean;
 }
 
 export class Task<TOut = unknown> extends EventEmitter implements Promise<TOut>, Trapper {
   public id = ++COUNTER;
 
-  private children: Set<Task> = new Set();
+  public readonly children: Set<Task> = new Set();
   private trappers: Set<Trapper> = new Set();
 
   private controller: Controller<TOut>;
@@ -147,7 +148,7 @@ export class Task<TOut = unknown> extends EventEmitter implements Promise<TOut>,
 
   trap(child: Task) {
     if(this.children.has(child)) {
-      if(child.state === 'errored') {
+      if(child.state === 'errored' && !this.options.ignoreChildErrors) {
         this.controls.reject(child.error!);
       }
       this.unlink(child);

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -1,7 +1,8 @@
+import './setup';
 import { describe, beforeEach, it } from 'mocha';
 import * as expect from 'expect';
 
-import { run, sleep, Operation, Task } from '../src/index';
+import { run, sleep, Operation, Effection, Task } from '../src/index';
 import { Deferred } from '../src/deferred';
 
 function createNumber(value: number) {
@@ -17,6 +18,11 @@ function *blowUp() {
 }
 
 describe('run', () => {
+  it('adds the new task to the global task', () => {
+    let task = run(Promise.resolve(123))
+    expect(Effection.root.children.has(task as Task)).toEqual(true);
+  });
+
   describe('with promise', () => {
     it('runs a promise to completion', async () => {
       let task = run(Promise.resolve(123))

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,7 @@
+import { Effection } from '../src/index';
+import { beforeEach } from 'mocha';
+
+beforeEach(async () => {
+  await Effection.reset();
+});
+

--- a/test/spawn.test.ts
+++ b/test/spawn.test.ts
@@ -1,3 +1,4 @@
+import './setup';
 import { describe, beforeEach, it } from 'mocha';
 import * as expect from 'expect';
 

--- a/test/task.test.ts
+++ b/test/task.test.ts
@@ -1,3 +1,4 @@
+import './setup';
 import { describe, beforeEach, it } from 'mocha';
 import * as expect from 'expect';
 


### PR DESCRIPTION
This adds a root task, accessible via `Effection.root`. All tasks spawned by `run` will be spawned as children of this root task. This means that `Effection.root.children` will list a tree of all currently running tasks. The root task has some special sauce so that when a child crashes, the root task itself does not crash.