### PR TITLE
Promise functions

### DIFF
--- a/src/controller/function-controller.ts
+++ b/src/controller/function-controller.ts
@@ -1,0 +1,63 @@
+import { Controller } from './controller';
+import { OperationFunction } from '../operation';
+import { Task } from '../task';
+import { HaltError } from '../halt-error';
+import { Deferred } from '../deferred';
+import { IteratorController } from './iterator-controller';
+
+const HALT = Symbol("halt");
+
+export class FunctionContoller<TOut> implements Controller<TOut> {
+  private promise: Promise<TOut>;
+  private haltSignal: Deferred<typeof HALT> = Deferred();
+  private startSignal: Deferred<{ controller: Controller<TOut> }> = Deferred();
+
+  constructor(private operation: OperationFunction<TOut>) {
+    this.promise = this.run();
+  }
+
+  start(task: Task<TOut>) {
+    try {
+      let controller: Controller<TOut>;
+      let result = this.operation(task);
+      controller = new IteratorController(result);
+      controller.start(task);
+      this.startSignal.resolve({ controller });
+    } catch(e) {
+      this.startSignal.reject(e);
+    }
+  }
+
+  private async run(): Promise<TOut> {
+    let { controller } = await this.startSignal.promise;
+
+    let result = await Promise.race([controller, this.haltSignal.promise]);
+
+    if(result === HALT) {
+      await controller.halt();
+      throw new HaltError()
+    } else {
+      return result;
+    }
+  }
+
+  async halt() {
+    this.haltSignal.resolve(HALT);
+  }
+
+  then<TResult1 = TOut, TResult2 = never>(onfulfilled?: ((value: TOut) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2> {
+    return this.promise.then(onfulfilled, onrejected);
+  }
+
+  catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<TOut | TResult> {
+    return this.promise.catch(onrejected);
+  }
+
+  finally(onfinally?: (() => void) | null | undefined): Promise<TOut> {
+    return this.promise.finally(onfinally);
+  }
+
+  get [Symbol.toStringTag](): string {
+    return '[FunctionContoller]'
+  }
+}

--- a/src/controller/function-controller.ts
+++ b/src/controller/function-controller.ts
@@ -3,7 +3,9 @@ import { OperationFunction } from '../operation';
 import { Task } from '../task';
 import { HaltError } from '../halt-error';
 import { Deferred } from '../deferred';
+import { isPromise } from '../predicates';
 import { IteratorController } from './iterator-controller';
+import { PromiseController } from './promise-controller';
 
 const HALT = Symbol("halt");
 
@@ -20,7 +22,11 @@ export class FunctionContoller<TOut> implements Controller<TOut> {
     try {
       let controller: Controller<TOut>;
       let result = this.operation(task);
-      controller = new IteratorController(result);
+      if(isPromise(result)) {
+        controller = new PromiseController(result);
+      } else {
+        controller = new IteratorController(result);
+      }
       controller.start(task);
       this.startSignal.resolve({ controller });
     } catch(e) {

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -2,6 +2,6 @@ import { Task } from './task';
 
 export type OperationIterator<TOut> = Generator<Operation<any>, TOut | undefined, any>;
 
-export type OperationFunction<TOut> = (task: Task<TOut>) => OperationIterator<TOut>;
+export type OperationFunction<TOut> = (task: Task<TOut>) => PromiseLike<TOut> | OperationIterator<TOut>;
 
 export type Operation<TOut> = OperationFunction<TOut> | PromiseLike<TOut> | undefined

--- a/src/predicates.ts
+++ b/src/predicates.ts
@@ -1,0 +1,7 @@
+export function isPromise(value: any): value is PromiseLike<unknown> {
+  return value && typeof(value.then) === 'function';
+}
+
+export function isGenerator(value: any): value is Iterator<unknown> {
+  return value && typeof(value.next) === 'function';
+}

--- a/src/task.ts
+++ b/src/task.ts
@@ -1,17 +1,10 @@
 import { PromiseController } from './controller/promise-controller';
-import { IteratorController } from './controller/iterator-controller';
+import { FunctionContoller } from './controller/function-controller';
 import { Controller } from './controller/controller';
 import { Operation } from './operation';
 import { Deferred } from './deferred';
+import { isPromise } from './predicates';
 import { swallowHalt, isHaltError } from './halt-error';
-
-function isPromise(value: any): value is PromiseLike<unknown> {
-  return value && typeof(value.then) === 'function';
-}
-
-function isGenerator(value: any): value is Iterator<unknown> {
-  return value && typeof(value.next) === 'function';
-}
 
 type TaskState = 'running' | 'halting' | 'halted' | 'erroring' | 'errored' | 'completing' | 'completed';
 
@@ -38,7 +31,7 @@ export class Task<TOut = unknown> implements Promise<TOut> {
     } else if(isPromise(operation)) {
       this.controller = new PromiseController(operation);
     } else if(typeof(operation) === 'function') {
-      this.controller = new IteratorController(operation);
+      this.controller = new FunctionContoller(operation);
     } else {
       throw new Error(`unkown type of operation: ${operation}`);
     }

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -196,4 +196,32 @@ describe('run', () => {
       expect(task.state).toEqual('halted');
     });
   });
+
+  describe('with promise function', () => {
+    it('runs a promise to completion', async () => {
+      let task = run((task) => Promise.resolve(123))
+      await expect(task).resolves.toEqual(123);
+      expect(task.state).toEqual('completed');
+      expect(task.result).toEqual(123);
+    });
+
+    it('rejects a failed promise', async () => {
+      let error = new Error('boom');
+      let task = run((task) => Promise.reject(error))
+      await expect(task).rejects.toEqual(error);
+      expect(task.state).toEqual('errored');
+      expect(task.error).toEqual(error);
+    });
+
+    it('can halt a promise', async () => {
+      let promise = new Promise(() => {});
+      let task = run((task) => promise);
+
+      task.halt();
+
+      await expect(task).rejects.toHaveProperty('message', 'halted')
+      expect(task.state).toEqual('halted');
+      expect(task.result).toEqual(undefined);
+    });
+  });
 });


### PR DESCRIPTION
Allows operation functions to return a promise rather than a generator. This will be convenient for writing low-level primitives where a generator is overkill.