### PR TITLE
Switch internal implementation to use state machine

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -1,6 +1,6 @@
 import { Task } from '../task';
 
-export interface Controller<TOut> extends Promise<TOut> {
-  start(task: Task<TOut>): void;
+export interface Controller<TOut> {
+  start(): void;
   halt(): void;
 }

--- a/src/controller/function-controller.ts
+++ b/src/controller/function-controller.ts
@@ -22,7 +22,7 @@ export class FunctionContoller<TOut> implements Controller<TOut> {
     try {
       result = this.operation(this.task);
     } catch(error) {
-      this.task.reject(error);
+      this.controls.reject(error);
       return;
     }
     let controller;

--- a/src/controller/function-controller.ts
+++ b/src/controller/function-controller.ts
@@ -2,7 +2,6 @@ import { Controller } from './controller';
 import { OperationFunction } from '../operation';
 import { Task, Controls } from '../task';
 import { HaltError } from '../halt-error';
-import { Deferred } from '../deferred';
 import { isPromise } from '../predicates';
 import { IteratorController } from './iterator-controller';
 import { PromiseController } from './promise-controller';
@@ -10,8 +9,6 @@ import { PromiseController } from './promise-controller';
 const HALT = Symbol("halt");
 
 export class FunctionContoller<TOut> implements Controller<TOut> {
-  private haltSignal: Deferred<typeof HALT> = Deferred();
-  private startSignal: Deferred<{ controller: Controller<TOut> }> = Deferred();
   private controller?: Controller<TOut>;
 
   constructor(private task: Task<TOut>, private controls: Controls<TOut>, private operation: OperationFunction<TOut>) {

--- a/src/controller/function-controller.ts
+++ b/src/controller/function-controller.ts
@@ -22,7 +22,7 @@ export class FunctionContoller<TOut> implements Controller<TOut> {
     try {
       result = this.operation(this.task);
     } catch(error) {
-      this.task.trapReject(error);
+      this.task.reject(error);
       return;
     }
     let controller;

--- a/src/controller/function-controller.ts
+++ b/src/controller/function-controller.ts
@@ -10,60 +10,36 @@ import { PromiseController } from './promise-controller';
 const HALT = Symbol("halt");
 
 export class FunctionContoller<TOut> implements Controller<TOut> {
-  private promise: Promise<TOut>;
   private haltSignal: Deferred<typeof HALT> = Deferred();
   private startSignal: Deferred<{ controller: Controller<TOut> }> = Deferred();
+  private controller?: Controller<TOut>;
 
-  constructor(private operation: OperationFunction<TOut>) {
-    this.promise = this.run();
+  constructor(private task: Task<TOut>, private operation: OperationFunction<TOut>) {
   }
 
-  start(task: Task<TOut>) {
+  start() {
+    let result;
     try {
-      let controller: Controller<TOut>;
-      let result = this.operation(task);
-      if(isPromise(result)) {
-        controller = new PromiseController(result);
-      } else {
-        controller = new IteratorController(result);
-      }
-      controller.start(task);
-      this.startSignal.resolve({ controller });
-    } catch(e) {
-      this.startSignal.reject(e);
+      result = this.operation(this.task);
+    } catch(error) {
+      this.task.trapReject(error);
+      return;
     }
-  }
-
-  private async run(): Promise<TOut> {
-    let { controller } = await this.startSignal.promise;
-
-    let result = await Promise.race([controller, this.haltSignal.promise]);
-
-    if(result === HALT) {
-      await controller.halt();
-      throw new HaltError()
+    let controller;
+    if(isPromise(result)) {
+      controller = new PromiseController(this.task, result);
     } else {
-      return result;
+      controller = new IteratorController(this.task, result);
     }
+    this.controller = controller;
+    controller.start();
   }
 
   async halt() {
-    this.haltSignal.resolve(HALT);
-  }
-
-  then<TResult1 = TOut, TResult2 = never>(onfulfilled?: ((value: TOut) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2> {
-    return this.promise.then(onfulfilled, onrejected);
-  }
-
-  catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<TOut | TResult> {
-    return this.promise.catch(onrejected);
-  }
-
-  finally(onfinally?: (() => void) | null | undefined): Promise<TOut> {
-    return this.promise.finally(onfinally);
-  }
-
-  get [Symbol.toStringTag](): string {
-    return '[FunctionContoller]'
+    if(this.controller) {
+      this.controller.halt();
+    } else {
+      throw new Error('INTERNAL ERROR: halt called before start, this should never happen');
+    }
   }
 }

--- a/src/controller/function-controller.ts
+++ b/src/controller/function-controller.ts
@@ -1,6 +1,6 @@
 import { Controller } from './controller';
 import { OperationFunction } from '../operation';
-import { Task } from '../task';
+import { Task, Controls } from '../task';
 import { HaltError } from '../halt-error';
 import { Deferred } from '../deferred';
 import { isPromise } from '../predicates';
@@ -14,7 +14,7 @@ export class FunctionContoller<TOut> implements Controller<TOut> {
   private startSignal: Deferred<{ controller: Controller<TOut> }> = Deferred();
   private controller?: Controller<TOut>;
 
-  constructor(private task: Task<TOut>, private operation: OperationFunction<TOut>) {
+  constructor(private task: Task<TOut>, private controls: Controls<TOut>, private operation: OperationFunction<TOut>) {
   }
 
   start() {
@@ -27,9 +27,9 @@ export class FunctionContoller<TOut> implements Controller<TOut> {
     }
     let controller;
     if(isPromise(result)) {
-      controller = new PromiseController(this.task, result);
+      controller = new PromiseController(this.controls, result);
     } else {
-      controller = new IteratorController(this.task, result);
+      controller = new IteratorController(this.controls, result);
     }
     this.controller = controller;
     controller.start();

--- a/src/controller/function-controller.ts
+++ b/src/controller/function-controller.ts
@@ -4,6 +4,7 @@ import { Task, Controls } from '../task';
 import { HaltError } from '../halt-error';
 import { isPromise } from '../predicates';
 import { IteratorController } from './iterator-controller';
+import { ResolutionController } from './resolution-controller';
 import { PromiseController } from './promise-controller';
 
 const HALT = Symbol("halt");
@@ -25,6 +26,8 @@ export class FunctionContoller<TOut> implements Controller<TOut> {
     let controller;
     if(isPromise(result)) {
       controller = new PromiseController(this.controls, result);
+    } else if(typeof(result) === 'function') {
+      controller = new ResolutionController(this.controls, result);
     } else {
       controller = new IteratorController(this.controls, result);
     }

--- a/src/controller/iterator-controller.ts
+++ b/src/controller/iterator-controller.ts
@@ -24,14 +24,14 @@ export class IteratorController<TOut> implements Controller<TOut>, Trapper {
     try {
       next = iter();
     } catch(error) {
-      this.task.trapReject(error);
+      this.task.reject(error);
       return;
     }
     if(next.done) {
       if(this.didHalt) {
-        this.task.trapHalt();
+        this.task.resume();
       } else {
-        this.task.trapResolve(next.value);
+        this.task.resolve(next.value);
       }
     } else {
       let subTask = new Task(next.value);
@@ -40,7 +40,7 @@ export class IteratorController<TOut> implements Controller<TOut>, Trapper {
     }
   }
 
-  trapChildExit(child: Task) {
+  trap(child: Task) {
     if(child.state === 'completed') {
       this.resume(() => this.iterator.next(child.result!));
     }

--- a/src/controller/iterator-controller.ts
+++ b/src/controller/iterator-controller.ts
@@ -1,6 +1,6 @@
 import { Controller } from './controller';
 import { OperationIterator } from '../operation';
-import { Task } from '../task';
+import { Task, Controls } from '../task';
 import { HaltError, swallowHalt } from '../halt-error';
 import { Operation } from '../operation';
 import { Deferred } from '../deferred';
@@ -11,7 +11,7 @@ const HALT = Symbol("halt");
 export class IteratorController<TOut> implements Controller<TOut>, Trapper {
   private didHalt: boolean = false;
 
-  constructor(private task: Task<TOut>, private iterator: OperationIterator<TOut>) {
+  constructor(private controls: Controls<TOut>, private iterator: OperationIterator<TOut>) {
   }
 
   // make this an async function to delay the first iteration until the next event loop tick
@@ -24,14 +24,14 @@ export class IteratorController<TOut> implements Controller<TOut>, Trapper {
     try {
       next = iter();
     } catch(error) {
-      this.task.reject(error);
+      this.controls.reject(error);
       return;
     }
     if(next.done) {
       if(this.didHalt) {
-        this.task.resume();
+        this.controls.resume();
       } else {
-        this.task.resolve(next.value);
+        this.controls.resolve(next.value);
       }
     } else {
       let subTask = new Task(next.value);

--- a/src/controller/iterator-controller.ts
+++ b/src/controller/iterator-controller.ts
@@ -27,7 +27,7 @@ export class IteratorController<TOut> implements Controller<TOut>, Trapper {
     }
     if(next.done) {
       if(this.didHalt) {
-        this.controls.resume();
+        this.controls.halted();
       } else {
         this.controls.resolve(next.value);
       }

--- a/src/controller/iterator-controller.ts
+++ b/src/controller/iterator-controller.ts
@@ -35,7 +35,7 @@ export class IteratorController<TOut> implements Controller<TOut>, Trapper {
       }
     } else {
       let subTask = new Task(next.value);
-      subTask.parent = this;
+      subTask.addTrapper(this);
       subTask.start();
     }
   }

--- a/src/controller/promise-controller.ts
+++ b/src/controller/promise-controller.ts
@@ -1,5 +1,5 @@
 import { Controller } from './controller';
-import { Task } from '../task';
+import { Controls } from '../task';
 import { HaltError, isHaltError } from '../halt-error';
 import { Deferred } from '../deferred';
 
@@ -9,19 +9,19 @@ export class PromiseController<TOut> implements Controller<TOut> {
 
   private haltSignal = Deferred<never>();
 
-  constructor(private task: Task<TOut>, private promise: PromiseLike<TOut>) {
+  constructor(private controls: Controls<TOut>, private promise: PromiseLike<TOut>) {
   }
 
   start() {
     Promise.race([this.promise, this.haltSignal.promise]).then(
       (value) => {
-        this.task.resolve(value);
+        this.controls.resolve(value);
       },
       (error) => {
         if(isHaltError(error)) {
-          this.task.resume();
+          this.controls.resume();
         } else {
-          this.task.reject(error);
+          this.controls.reject(error);
         }
       }
     )

--- a/src/controller/promise-controller.ts
+++ b/src/controller/promise-controller.ts
@@ -15,13 +15,13 @@ export class PromiseController<TOut> implements Controller<TOut> {
   start() {
     Promise.race([this.promise, this.haltSignal.promise]).then(
       (value) => {
-        this.task.trapResolve(value);
+        this.task.resolve(value);
       },
       (error) => {
         if(isHaltError(error)) {
-          this.task.trapHalt();
+          this.task.resume();
         } else {
-          this.task.trapReject(error);
+          this.task.reject(error);
         }
       }
     )

--- a/src/controller/promise-controller.ts
+++ b/src/controller/promise-controller.ts
@@ -18,7 +18,7 @@ export class PromiseController<TOut> implements Controller<TOut> {
     Promise.race([this.promise, this.haltSignal.promise]).then(
       (value) => {
         if(value === HALT) {
-          this.controls.resume();
+          this.controls.halted();
         } else {
           this.controls.resolve(value);
         }

--- a/src/controller/resolution-controller.ts
+++ b/src/controller/resolution-controller.ts
@@ -1,0 +1,20 @@
+import { Controller } from './controller';
+import { OperationResolution } from '../operation';
+import { Controls } from '../task';
+
+export class ResolutionController<TOut> implements Controller<TOut> {
+  constructor(private controls: Controls<TOut>, private resolution: OperationResolution<TOut>) {
+  }
+
+  start() {
+    try {
+      this.resolution(this.controls.resolve, this.controls.reject);
+    } catch(error) {
+      this.controls.reject(error);
+    }
+  }
+
+  halt() {
+    this.controls.halted();
+  }
+}

--- a/src/controller/suspend-controller.ts
+++ b/src/controller/suspend-controller.ts
@@ -8,6 +8,6 @@ export class SuspendController<TOut> implements Controller<TOut> {
   start() {}
 
   halt() {
-    this.controls.resume();
+    this.controls.halted();
   }
 }

--- a/src/controller/suspend-controller.ts
+++ b/src/controller/suspend-controller.ts
@@ -1,0 +1,13 @@
+import { Controller } from './controller';
+import { Controls } from '../task';
+
+export class SuspendController<TOut> implements Controller<TOut> {
+  constructor(private controls: Controls<TOut>) {
+  }
+
+  start() {}
+
+  halt() {
+    this.controls.resume();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,7 @@ export { Operation } from './operation';
 export { sleep } from './sleep';
 
 export function run<TOut>(operation?: Operation<TOut>): Task<TOut> {
-  return new Task(operation);
+  let task = new Task(operation);
+  task.start();
+  return task;
 }

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -2,6 +2,8 @@ import { Task } from './task';
 
 export type OperationIterator<TOut> = Generator<Operation<any>, TOut | undefined, any>;
 
-export type OperationFunction<TOut> = (task: Task<TOut>) => PromiseLike<TOut> | OperationIterator<TOut>;
+export type OperationResolution<TOut> = (resolve: (value: TOut) => void, reject: (error: Error) => void) => void;
+
+export type OperationFunction<TOut> = (task: Task<TOut>) => PromiseLike<TOut> | OperationIterator<TOut> | OperationResolution<TOut>;
 
 export type Operation<TOut> = OperationFunction<TOut> | PromiseLike<TOut> | undefined

--- a/src/state-machine.ts
+++ b/src/state-machine.ts
@@ -1,0 +1,72 @@
+import { EventEmitter } from 'events';
+
+export type State = 'pending' | 'running' | 'halting' | 'halted' | 'erroring' | 'errored' | 'completing' | 'completed';
+
+function f(value: string) { return JSON.stringify(value) };
+
+export class StateMachine {
+  current: State = 'pending';
+
+  get isFinishing(): boolean {
+    return ['completing', 'halting', 'erroring'].includes(this.current);
+  }
+
+  constructor(private emitter: EventEmitter) {}
+
+  private transition(event: string, validTransitions: Partial<Record<State, State>>) {
+    let from = this.current;
+    let to = validTransitions[from];
+
+    if(!to) {
+      let options = Object.keys(validTransitions).map(f).join(', ');
+      throw new Error(`INTERNAL ERROR: state transition ${f(event)} is not valid in current state ${f(from)}, should be one of ${options}`)
+    }
+
+    this.current = to;
+    this.emitter.emit('state', { from, to });
+  }
+
+  start() {
+    this.transition('start', {
+      'pending': 'running',
+    });
+  }
+
+  resolve() {
+    this.transition('resolve', {
+      'running': 'completing',
+      'completing': 'completing',
+      'erroring': 'erroring',
+      'halting': 'halting',
+    });
+  }
+
+  reject() {
+    this.transition('reject', {
+      'running': 'erroring',
+      'completing': 'erroring',
+      'halting': 'erroring',
+      'erroring': 'erroring',
+    });
+  }
+
+  halt() {
+    this.transition('halt', {
+      'running': 'halting',
+      'completing': 'halting',
+      'halting': 'halting',
+      'erroring': 'erroring',
+      'halted': 'halted',
+      'completed': 'completed',
+      'errored': 'errored',
+    });
+  }
+
+  finish() {
+    this.transition('finish', {
+      'completing': 'completed',
+      'erroring': 'errored',
+      'halting': 'halted',
+    });
+  }
+}

--- a/src/task.ts
+++ b/src/task.ts
@@ -23,7 +23,6 @@ export class Task<TOut = unknown> extends EventEmitter implements Promise<TOut>,
 
   private children: Set<Task> = new Set();
   private trappers: Set<Trapper> = new Set();
-  private signal: Deferred<never> = Deferred();
 
   private controller: Controller<TOut>;
   private deferred = Deferred<TOut>();
@@ -81,6 +80,7 @@ export class Task<TOut = unknown> extends EventEmitter implements Promise<TOut>,
     } else {
       throw new Error(`unkown type of operation: ${operation}`);
     }
+    this.deferred.promise.catch(() => {}); // prevent uncaught promise warnings
   }
 
   start() {
@@ -148,7 +148,7 @@ export class Task<TOut = unknown> extends EventEmitter implements Promise<TOut>,
     this.stateMachine.halt();
     this.controller.halt();
     this.children.forEach((c) => c.halt());
-    await this.catch(swallowHalt);
+    await this.catch(() => {});
   }
 
   get [Symbol.toStringTag](): string {

--- a/src/task.ts
+++ b/src/task.ts
@@ -4,104 +4,66 @@ import { Controller } from './controller/controller';
 import { Operation } from './operation';
 import { Deferred } from './deferred';
 import { isPromise } from './predicates';
+import { Trapper } from './trapper';
 import { swallowHalt, isHaltError } from './halt-error';
 import { EventEmitter } from 'events';
-
-type TaskState = 'running' | 'halting' | 'halted' | 'erroring' | 'errored' | 'completing' | 'completed';
+import { StateMachine, State } from './state-machine';
+import { HaltError } from './halt-error';
 
 let COUNTER = 0;
 
-export class Task<TOut = unknown> extends EventEmitter implements Promise<TOut> {
+export class Task<TOut = unknown> extends EventEmitter implements Promise<TOut>, Trapper {
   public id = ++COUNTER;
 
   private children: Set<Task> = new Set();
   private signal: Deferred<never> = Deferred();
 
   private controller: Controller<TOut>;
-  private promise: Promise<TOut>;
-  private parent?: Task;
+  private deferred = Deferred<TOut>();
+  public parent?: Trapper;
 
-  public state: TaskState = 'running';
+  private stateMachine = new StateMachine(this);
 
   public result?: TOut;
   public error?: Error;
 
+  get state(): State {
+    return this.stateMachine.current;
+  }
+
   constructor(private operation: Operation<TOut>) {
     super();
     if(!operation) {
-      this.controller = new PromiseController(new Promise(() => {}));
+      this.controller = new PromiseController(this, new Promise(() => {}));
     } else if(isPromise(operation)) {
-      this.controller = new PromiseController(operation);
+      this.controller = new PromiseController(this, operation);
     } else if(typeof(operation) === 'function') {
-      this.controller = new FunctionContoller(operation);
+      this.controller = new FunctionContoller(this, operation);
     } else {
       throw new Error(`unkown type of operation: ${operation}`);
     }
-    this.promise = this.run();
-    this.controller.start(this);
   }
 
-  private async haltChildren(silent = false) {
-    await Promise.all(Array.from(this.children).map(async (c) => {
-      try {
-        await c.halt();
-      } catch(error) {
-        if(!silent) {
-          throw error;
-        }
-      }
-    }));
+  start() {
+    this.stateMachine.start();
+    this.controller.start();
   }
 
-  private async run(): Promise<TOut> {
-    try {
-      let result = await Promise.race([this.signal.promise, this.controller]);
-      this.result = result;
-      this.setState('completing');
-      await this.haltChildren();
-      this.setState('completed');
-      return result;
-    } catch(error) {
-      if(isHaltError(error)) {
-        this.setState('halting');
-        try {
-          await this.haltChildren();
-          this.setState('halted');
-        } catch(error) {
-          this.error = error;
-          this.setState('errored');
-          throw(error);
-        }
-        throw(error);
-      } else {
-        this.setState('erroring');
-        this.error = error;
-        await this.haltChildren(true);
-        this.setState('errored');
-        throw(error);
-      }
-    } finally {
-      if(this.parent) {
-        this.parent.trapExit(this as Task);
-      }
-    }
-  }
-
-  async halt() {
-    await this.controller.halt();
-    await this.then(() => {}, swallowHalt);
+  private haltChildren(silent = false) {
+    this.children.forEach((c) => c.halt());
+    this.resume();
   }
 
   then<TResult1 = TOut, TResult2 = never>(onfulfilled?: ((value: TOut) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2> {
-    return this.promise.then(onfulfilled, onrejected);
+    return this.deferred.promise.then(onfulfilled, onrejected);
   }
 
   catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<TOut | TResult> {
-    return this.promise.catch(onrejected);
+    return this.deferred.promise.catch(onrejected);
   }
 
   finally(onfinally?: (() => void) | null | undefined): Promise<TOut> {
-    return this.promise.finally(onfinally);
+    return this.deferred.promise.finally(onfinally);
   }
 
   spawn<R>(operation?: Operation<R>): Task<R> {
@@ -110,6 +72,7 @@ export class Task<TOut = unknown> extends EventEmitter implements Promise<TOut> 
     }
     let child = new Task(operation);
     this.link(child as Task);
+    child.start();
     return child;
   }
 
@@ -125,17 +88,53 @@ export class Task<TOut = unknown> extends EventEmitter implements Promise<TOut> 
     this.emit('unlink', child);
   }
 
-  trapExit(child: Task) {
-    if(child.state === 'errored' && child.error) {
-      this.signal.reject(child.error);
-    }
-    this.unlink(child);
+  trapResolve(result: TOut) {
+    this.result = result;
+    this.stateMachine.resolve();
+    this.haltChildren();
   }
 
-  setState(state: TaskState) {
-    let from = this.state;
-    this.state = state;
-    this.emit('state', { from, to: state });
+  trapReject(error: Error) {
+    this.result = undefined; // clear result if it has previously been set
+    this.error = error;
+    this.stateMachine.reject();
+    this.haltChildren();
+  }
+
+  trapHalt() {
+    this.haltChildren();
+  }
+
+  trapChildExit(child: Task) {
+    if(child.state === 'errored') {
+      this.trapReject(child.error!);
+    }
+    this.unlink(child);
+    this.resume();
+  }
+
+  resume() {
+    if(this.stateMachine.isFinishing && this.children.size === 0) {
+      this.stateMachine.finish();
+
+      if(this.parent) {
+        this.parent.trapChildExit(this as Task);
+      }
+
+      if(this.state === 'completed') {
+        this.deferred.resolve(this.result!);
+      } else if(this.state === 'halted') {
+        this.deferred.reject(new HaltError());
+      } else if(this.state === 'errored') {
+        this.deferred.reject(this.error!);
+      }
+    }
+  }
+
+  async halt() {
+    this.stateMachine.halt();
+    this.controller.halt();
+    await this.catch(swallowHalt);
   }
 
   get [Symbol.toStringTag](): string {

--- a/src/task.ts
+++ b/src/task.ts
@@ -1,3 +1,4 @@
+import { SuspendController } from './controller/suspend-controller';
 import { PromiseController } from './controller/promise-controller';
 import { FunctionContoller } from './controller/function-controller';
 import { Controller } from './controller/controller';
@@ -72,7 +73,7 @@ export class Task<TOut = unknown> extends EventEmitter implements Promise<TOut>,
   constructor(private operation: Operation<TOut>) {
     super();
     if(!operation) {
-      this.controller = new PromiseController(this.controls, new Promise(() => {}));
+      this.controller = new SuspendController(this.controls);
     } else if(isPromise(operation)) {
       this.controller = new PromiseController(this.controls, operation);
     } else if(typeof(operation) === 'function') {

--- a/src/trapper.ts
+++ b/src/trapper.ts
@@ -1,5 +1,5 @@
 import { Task } from './task';
 
 export interface Trapper {
-  trapChildExit(task: Task): void;
+  trap(task: Task): void;
 }

--- a/src/trapper.ts
+++ b/src/trapper.ts
@@ -1,0 +1,5 @@
+import { Task } from './task';
+
+export interface Trapper {
+  trapChildExit(task: Task): void;
+}

--- a/test/fork.test.ts
+++ b/test/fork.test.ts
@@ -1,19 +1,8 @@
 import { describe, beforeEach, it } from 'mocha';
 import * as expect from 'expect';
 
-import { run, Task } from '../src/index';
+import { run, sleep, Task } from '../src/index';
 import { Deferred } from '../src/deferred';
-
-function* sleep(ms: number) {
-  let timeout;
-  let deferred = Deferred();
-  try {
-    timeout = setTimeout(deferred.resolve, ms);
-    yield deferred.promise;
-  } finally {
-    timeout && clearTimeout(timeout);
-  }
-};
 
 describe('fork', () => {
   it('can fork a new child task', async () => {

--- a/test/fork.test.ts
+++ b/test/fork.test.ts
@@ -1,0 +1,167 @@
+import { describe, beforeEach, it } from 'mocha';
+import * as expect from 'expect';
+
+import { run, Task } from '../src/index';
+import { Deferred } from '../src/deferred';
+
+function* sleep(ms: number) {
+  let timeout;
+  let deferred = Deferred();
+  try {
+    timeout = setTimeout(deferred.resolve, ms);
+    yield deferred.promise;
+  } finally {
+    timeout && clearTimeout(timeout);
+  }
+};
+
+describe('fork', () => {
+  it('can fork a new child task', async () => {
+    let root = run(function*(context: Task) {
+      let child = context.fork(function*() {
+        let one: number = yield Promise.resolve(12);
+        let two: number = yield Promise.resolve(55);
+
+        return one + two;
+      });
+
+      return yield child;
+    });
+    await expect(root).resolves.toEqual(67);
+    expect(root.state).toEqual('completed');
+  });
+
+  it('halts child when halted', async () => {
+    let child: Task<void> | undefined;
+    let root = run(function*(context: Task) {
+      child = context.fork(function*() {
+        yield;
+      });
+
+      yield;
+    });
+
+    await root.halt();
+
+    await expect(child).rejects.toHaveProperty('message', 'halted')
+    expect(root.state).toEqual('halted');
+    expect(child && child.state).toEqual('halted');
+  });
+
+  it('blocks on child when finishing normally', async () => {
+    let child: Task<string> | undefined;
+    let root = run(function*(context: Task) {
+      child = context.fork(function*() {
+        yield sleep(5);
+        return 'foo';
+      });
+
+      return 1;
+    });
+
+    await expect(root).resolves.toEqual(1);
+    await expect(child).resolves.toEqual('foo');
+    expect(root.state).toEqual('completed');
+    expect(child && child.state).toEqual('completed');
+  });
+
+  it('halts child when errored', async () => {
+    let child;
+    let root = run(function*(context: Task) {
+      child = context.fork(function*() {
+        yield;
+      });
+
+      throw new Error('boom');
+    });
+
+    await expect(root).rejects.toHaveProperty('message', 'boom');
+    await expect(child).rejects.toHaveProperty('message', 'halted');
+  });
+
+  it('rejects parent when child errors', async () => {
+    let child;
+    let error = new Error("moo");
+    let root = run(function*(context: Task) {
+      child = context.fork(function*() {
+        throw error;
+      });
+
+      yield;
+    });
+
+    await expect(child).rejects.toEqual(error);
+    await expect(root).rejects.toEqual(error);
+    expect(root.state).toEqual('errored');
+  });
+
+  it('finishes normally when child halts', async () => {
+    let child;
+    let root = run(function*(context: Task<string>) {
+      child = context.fork();
+      yield child.halt();
+
+      return "foo";
+    });
+
+    await expect(child).rejects.toHaveProperty('message', 'halted');
+    await expect(root).resolves.toEqual("foo");
+    expect(root.state).toEqual('completed');
+  });
+
+  it('rejects when child errors during completing', async () => {
+    let child;
+    let root = run(function*(context: Task<string>) {
+      child = context.fork(function*() {
+        try {
+          yield sleep(5);
+        } finally {
+          throw new Error("moo");
+        }
+      });
+      return "foo";
+    });
+
+    await expect(root).rejects.toHaveProperty('message', 'moo');
+    expect(root.state).toEqual('errored');
+  });
+
+  it('rejects when child errors during halting', async () => {
+    let child;
+    let root = run(function*(context: Task<string>) {
+      child = context.fork(function*(foo) {
+        try {
+          yield
+        } finally {
+          throw new Error("moo");
+        }
+      });
+      yield;
+      return "foo";
+    });
+
+    root.halt();
+
+    await expect(root).rejects.toHaveProperty('message', 'moo');
+    expect(root.state).toEqual('errored');
+  });
+
+  it('throws an error when called after controller finishes', async () => {
+    let child;
+    let root = run(function*(context: Task) {
+      child = context.fork(function*() {
+        try {
+          yield sleep(1);
+        } finally {
+          yield sleep(100);
+        }
+      });
+
+      yield sleep(10);
+    });
+
+    await run(sleep(20));
+
+    expect(() => root.fork()).toThrowError('cannot fork a child on a task which is not running');
+  });
+});

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -2,6 +2,7 @@ import { describe, beforeEach, it } from 'mocha';
 import * as expect from 'expect';
 
 import { run, sleep, Operation } from '../src/index';
+import { Deferred } from '../src/deferred';
 
 function createNumber(value: number) {
   return function*() {
@@ -159,23 +160,21 @@ describe('run', () => {
     });
 
     it('can suspend in finally block', async () => {
-      let callable: Operation<unknown>
-      let eventually = new Promise((resolve) => {
-        callable = function*() { resolve('did run'); }
-      });
+      let eventually = Deferred();
 
       let task = run(function*() {
         try {
           yield;
         } finally {
-          yield callable;
+          yield sleep(10);
+          eventually.resolve(123);
         }
       });
 
       task.halt();
 
-      await expect(eventually).resolves.toEqual("did run");
-      expect(task.state).toEqual('running');
+      await expect(eventually.promise).resolves.toEqual(123);
+      expect(task.state).toEqual('halted');
     });
 
     it('can await halt', async () => {

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -46,8 +46,22 @@ describe('run', () => {
   });
 
   describe('with undefined', () => {
-    it('suspends indefinitely', () => {
+    it('suspends indefinitely', async () => {
       let task = run();
+
+      await run(sleep(10));
+
+      expect(task.state).toEqual('running');
+    });
+
+    it('can be halted', async () => {
+      let task = run();
+
+      await task.halt();
+
+      await expect(task).rejects.toHaveProperty('message', 'halted')
+      expect(task.state).toEqual('halted');
+      expect(task.result).toEqual(undefined);
     });
   });
 

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -65,6 +65,82 @@ describe('run', () => {
     });
   });
 
+  describe('with resolution function', () => {
+    it('resolves when resolve is called', async () => {
+      let task = run(() => {
+        return (resolve, reject) => {
+          setTimeout(() => resolve(123), 5)
+        }
+      });
+      await expect(task).resolves.toEqual(123);
+      expect(task.state).toEqual('completed');
+      expect(task.result).toEqual(123);
+    });
+
+    it('rejects when reject is called', async () => {
+      let task = run(() => {
+        return (resolve, reject) => {
+          setTimeout(() => reject(new Error('boom')), 5)
+        }
+      });
+      await expect(task).rejects.toHaveProperty('message', 'boom');
+      expect(task.state).toEqual('errored');
+      expect(task.error).toHaveProperty('message', 'boom');
+    });
+
+    it('rejects when error is thrown in function', async () => {
+      let task = run(() => {
+        return (resolve, reject) => {
+          throw new Error('boom');
+        }
+      });
+      await expect(task).rejects.toHaveProperty('message', 'boom');
+      expect(task.state).toEqual('errored');
+      expect(task.error).toHaveProperty('message', 'boom');
+    });
+
+    it('can be halted', async () => {
+      let task = run(() => {
+        return (resolve, reject) => {
+        }
+      });
+
+      await task.halt();
+
+      await expect(task).rejects.toHaveProperty('message', 'halted')
+      expect(task.state).toEqual('halted');
+      expect(task.result).toEqual(undefined);
+    });
+  });
+
+  describe('with promise function', () => {
+    it('runs a promise to completion', async () => {
+      let task = run((task) => Promise.resolve(123))
+      await expect(task).resolves.toEqual(123);
+      expect(task.state).toEqual('completed');
+      expect(task.result).toEqual(123);
+    });
+
+    it('rejects a failed promise', async () => {
+      let error = new Error('boom');
+      let task = run((task) => Promise.reject(error))
+      await expect(task).rejects.toEqual(error);
+      expect(task.state).toEqual('errored');
+      expect(task.error).toEqual(error);
+    });
+
+    it('can halt a promise', async () => {
+      let promise = new Promise(() => {});
+      let task = run((task) => promise);
+
+      task.halt();
+
+      await expect(task).rejects.toHaveProperty('message', 'halted')
+      expect(task.state).toEqual('halted');
+      expect(task.result).toEqual(undefined);
+    });
+  });
+
   describe('with generator function', () => {
     it('can compose multiple promises via generator', async () => {
       let task = run(function*() {

--- a/test/spawn.test.ts
+++ b/test/spawn.test.ts
@@ -152,4 +152,24 @@ describe('spawn', () => {
 
     expect(() => root.spawn()).toThrowError('cannot spawn a child on a task which is not running');
   });
+
+  it('halts when child finishes during asynchronous halt', async () => {
+    let child;
+    let didFinish = false;
+    let root = run(function*(context: Task) {
+      context.spawn(function*() {
+        yield sleep(5)
+      });
+      try {
+        yield;
+      } finally {
+        yield sleep(20);
+        didFinish = true;
+      }
+    });
+
+    await root.halt();
+
+    expect(didFinish).toEqual(true);
+  });
 });

--- a/test/spawn.test.ts
+++ b/test/spawn.test.ts
@@ -4,10 +4,6 @@ import * as expect from 'expect';
 import { run, sleep, Task } from '../src/index';
 import { Deferred } from '../src/deferred';
 
-process.on('unhandledRejection', (reason, promise) => {
-  // silence warnings in tests
-});
-
 describe('spawn', () => {
   it('can spawn a new child task', async () => {
     let root = run(function*(context: Task) {
@@ -132,7 +128,7 @@ describe('spawn', () => {
       return "foo";
     });
 
-    root.halt();
+    await root.halt();
 
     await expect(root).rejects.toHaveProperty('message', 'moo');
     expect(root.state).toEqual('errored');

--- a/test/task.test.ts
+++ b/test/task.test.ts
@@ -7,13 +7,16 @@ describe('Task', () => {
   describe('event: state', () => {
     it('is triggered when a task changes state', async () => {
       let events: { to: string, from: string }[] = []
-      let task = run(function*() { sleep(5) });
+      let task = new Task(function*() { sleep(5) });
 
       task.on('state', (transition) => events.push(transition));
+
+      task.start();
 
       await task;
 
       expect(events).toEqual([
+        { from: 'pending', to: 'running' },
         { from: 'running', to: 'completing' },
         { from: 'completing', to: 'completed' },
       ]);
@@ -40,7 +43,7 @@ describe('Task', () => {
 
       task.on('unlink', (child) => events.push(child));
 
-      let child = task.spawn(function*() { sleep(5); return 1 });
+      let child = task.spawn(function*() { yield sleep(5); return 1 });
 
       expect(events).toEqual([]);
       await child;
@@ -53,7 +56,7 @@ describe('Task', () => {
 
       task.on('unlink', (child) => events.push(child));
 
-      let child = task.spawn(function*() { sleep(5); return 1 });
+      let child = task.spawn(function*() { yield sleep(5); return 1 });
 
       expect(events).toEqual([]);
       await child.halt();


### PR DESCRIPTION
This effectively switches *back* to using an explicit state machine, just like effection 0.7. The advantage we get from this is better control over the event loop, see #20 and #16.

There is still a lot to be done, but personally I find this implementation *much* easier to understand.